### PR TITLE
rename application and methods to pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
-[![CircleCI](https://circleci.com/gh/18F/federalist-garden-build.svg?style=svg)](https://circleci.com/gh/18F/federalist-garden-build)
-[![Maintainability](https://api.codeclimate.com/v1/badges/b7ddc95a6745610b685b/maintainability)](https://codeclimate.com/github/18F/federalist-garden-build/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/b7ddc95a6745610b685b/test_coverage)](https://codeclimate.com/github/18F/federalist-garden-build/test_coverage)
+# Pages Build Container
 
-# Federalist Garden Build
-
-Docker image for building and publishing static sites as part of the Federalist platform.
+Docker image for building and publishing static sites as part of the cloud.gov Pages platform.
 
 Generally, site builds work in three stages: clone, build, and publish. Each stage is broken down into a number of steps. First, the container checks out the site from GitHub. Then it builds the site with the specified build engine. Then it gzip compresses text files and sets cache control headers. Finally, it uploads the built site to S3, and also creates redirect objects for directories, such as `/path` => `/path/`.
 
@@ -36,7 +32,7 @@ docker-compose run --rm app python main.py [options]
 ```
 # build arguments provided as a JSON encoded string
 
-cf run-task federalist-build-container "python main.py -p '{\"foo\": \"bar\"}'" --name "build-123"
+cf run-task pages-build-container "python main.py -p '{\"foo\": \"bar\"}'" --name "build-123"
 ```
 
 ```
@@ -92,13 +88,13 @@ The following environment variables are available during site builds and when ru
 #### Requirements
 - [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/)
 - AWS S3 bucket name and associated credentials (key, secret, region)
-- A Github repository with a Federalist-compatible site
+- A Github repository with a Pages-compatible site
 - A Github Personal Access Token if building a private repository, see [creating a new personal token for your GitHub account](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) for more information.
 
 #### Clone the repository
 ```sh
-  git clone git@github.com:18F/federalist-garden-build.git
-  cd federalist-garden-build
+  git clone git@github.com:cloud-gov/pages-build-container.git
+  cd pages-build-container
 ```
 
 #### Create build arguments
@@ -140,7 +136,7 @@ docker-compose up -d --no-deps db
 
 2. Run psql in the container
 ```
-docker-compose exec db psql -U postgres -d federalist
+docker-compose exec db psql -U postgres -d pages
 ```
 
 ### Inspecting logs
@@ -190,6 +186,7 @@ This project is in the worldwide [public domain](LICENSE.md). As stated in [CONT
 > All contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.
 
 [Federalist]: https://federalist.18f.gov
+[cloud.gov Pages]: https://cloud.gov/pages
 [Docker Compose]: https://docs.docker.com/compose/install/
 [Docker]: https://docs.docker.com/engine/installation/
-[federalist-builder]: https://github.com/18f/federalist-builder
+[pages-builder]: https://github.com/cloud-gov/pages-builder

--- a/ci/federalist-pipeline.yml
+++ b/ci/federalist-pipeline.yml
@@ -181,14 +181,14 @@ resources:
     type: git
     icon: github
     source:
-      uri: ((git-base-url))/((garden-build-repository-path))
+      uri: ((git-base-url))/((build-container-repository-path))
       branch: main
 
   - name: pr-main
     type: pull-request
     check_every: 1m
     source:
-      repository: ((garden-build-repository-path))
+      repository: ((build-container-repository-path))
       access_token: ((gh-access-token))
       base_branch: main
       disable_forks: true
@@ -210,8 +210,8 @@ resources:
     type: cogito
     check_every: 1h
     source:
-      owner: 18F
-      repo: federalist-garden-build
+      owner: cloud-gov
+      repo: pages-build-container
       access_token: ((gh-access-token))
       context_prefix: concourse
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -248,14 +248,14 @@ resources:
     type: git
     icon: github
     source:
-      uri: ((git-base-url))/((garden-build-repository-path))
+      uri: ((git-base-url))/((build-container-repository-path))
       branch: ((git-branch))
 
   - name: pr-((git-branch))
     type: pull-request
     check_every: 1m
     source:
-      repository: ((garden-build-repository-path))
+      repository: ((build-container-repository-path))
       access_token: ((gh-access-token))
       base_branch: ((git-branch))
       disable_forks: true
@@ -277,8 +277,8 @@ resources:
     type: cogito
     check_every: 1h
     source:
-      owner: 18F
-      repo: federalist-garden-build
+      owner: cloud-gov
+      repo: pages-build-container
       access_token: ((gh-access-token))
       context_prefix: concourse
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - db
     environment:
       CACHE_CONTROL: max-age=60
-      DATABASE_URL: postgresql://postgres:password@db/federalist
+      DATABASE_URL: postgresql://postgres:password@db/pages
       USER_ENVIRONMENT_VARIABLE_KEY: shhhhhhh
 
   app:
@@ -31,7 +31,7 @@ services:
       - db
     environment:
       CACHE_CONTROL: max-age=60
-      DATABASE_URL: postgresql://postgres:password@db/federalist
+      DATABASE_URL: postgresql://postgres:password@db/pages
       USER_ENVIRONMENT_VARIABLE_KEY: shhhhhhh
 
   echoserver:
@@ -55,14 +55,14 @@ services:
     volumes:
       - ./tmp/db:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres -d federalist"]
+      test: ["CMD-SHELL", "pg_isready -U postgres -d pages"]
       interval: 10s
       timeout: 5s
       retries: 5      
     environment:
       POSTGRES_PASSWORD: password
       POSTGRES_USER: postgres
-      POSTGRES_DB: federalist
+      POSTGRES_DB: pages
 
   test:
     build:

--- a/src/build.py
+++ b/src/build.py
@@ -227,7 +227,7 @@ def build(
 
         err_message = (
             f'Unexpected build({build_info}) error. Please try '
-            'again and contact federalist-support if it persists.'
+            'again and contact pages-support if it persists.'
         )
 
         post_build_error(status_callback, err_message, commit_sha)

--- a/src/log_utils/remote_logs.py
+++ b/src/log_utils/remote_logs.py
@@ -41,7 +41,7 @@ def post_build_error(status_callback_url, error_output, commit_sha=None):
     '''
     POST a STATUS_ERROR status with message to the status_callback_url
     '''
-    # Post to the Federalist web application endpoint with status and output
+    # Post to the Pages web application endpoint with status and output
     post_status(
         status_callback_url, status=STATUS_ERROR, output=error_output, commit_sha=commit_sha
     )
@@ -60,5 +60,5 @@ def post_build_timeout(status_callback_url, commit_sha=None):
     '''
     output = 'The build did not complete. It may have timed out.'
 
-    # Post to the Federalist web application with status and output
+    # Post to the Pages web application with status and output
     post_status(status_callback_url, status=STATUS_ERROR, output=output, commit_sha=commit_sha)

--- a/src/main.py
+++ b/src/main.py
@@ -25,7 +25,7 @@ def load_vcap():
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Run a federalist build')
+    parser = argparse.ArgumentParser(description='Run a pages build')
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('-p', '--params', dest='params',
                        help='A JSON encoded string',

--- a/src/steps/build.py
+++ b/src/steps/build.py
@@ -122,7 +122,7 @@ def is_supported_ruby_version(version):
 
         if version == RUBY_VERSION_MIN:
             logger.warning(
-                f'WARNING: Ruby {RUBY_VERSION_MIN} will soon reach end-of-life, at which point Federalist will no longer support it.')  # noqa: E501
+                f'WARNING: Ruby {RUBY_VERSION_MIN} will soon reach end-of-life, at which point Pages will no longer support it.')  # noqa: E501
             logger.warning(upgrade_msg)
 
     return is_supported
@@ -152,7 +152,7 @@ def setup_node():
                     echo "Switching to node version $RAW_VERSION specified in .nvmrc"
 
                     if [[ "$MAJOR_VERSION" -eq 12 ]]; then
-                        echo "WARNING: Node $RAW_VERSION will reach end-of-life on 4-30-2022, at which point Federalist will no longer support it."
+                        echo "WARNING: Node $RAW_VERSION will reach end-of-life on 4-30-2022, at which point Pages will no longer support it."
                         echo "Please upgrade to LTS major version 14 or 16, see https://nodejs.org/en/about/releases/ for details."
                     fi
 

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -352,7 +352,7 @@ class TestSetupRuby():
 
         mock_logger.warning.assert_has_calls([
             call(
-                f'WARNING: Ruby {min_ruby_version} will soon reach end-of-life, at which point Federalist will no longer support it.'),  # noqa: E501
+                f'WARNING: Ruby {min_ruby_version} will soon reach end-of-life, at which point Pages will no longer support it.'),  # noqa: E501
             call('Please upgrade to an actively supported version, see https://www.ruby-lang.org/en/downloads/branches/ for details.')  # noqa: E501
         ])
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- rename application and methods to `pages`
- Many things here are left as `federalist` to ease migration difficulty:
  - `npm run federalist` and `federalist.json` will function as normally. 
  - services named `federalist-((env))-rds` and `federalist-((env))-uev-key` are left as is

## security considerations
Renaming includes some deployment keys/application names
