### PR TITLE
use pages 404 page

### DIFF
--- a/src/publishing/s3publisher.py
+++ b/src/publishing/s3publisher.py
@@ -88,8 +88,8 @@ def publish_to_s3(directory, base_url, site_prefix, bucket, federalist_config,
     filename_404 = directory + '/404.html'
     if not path.isfile(filename_404):
         default_404_url = ('https://raw.githubusercontent.com'
-                           '/18F/federalist-404-page/master/'
-                           '404-federalist-client.html')
+                           '/cloud-gov/pages-404-page/main/'
+                           '404-pages-client.html')
         default_404 = requests.get(default_404_url)
         makedirs(path.dirname(filename_404), exist_ok=True)
         with open(filename_404, "w+") as f:

--- a/test/publishing/test_s3publisher.py
+++ b/test/publishing/test_s3publisher.py
@@ -121,8 +121,8 @@ def test_publish_to_s3(tmpdir, s3_client):
     # Create mock for default 404 page request
     with requests_mock.mock() as m:
         m.get(('https://raw.githubusercontent.com'
-               '/18F/federalist-404-page/master/'
-               '404-federalist-client.html'),
+               '/cloud-gov/pages-404-page/main/'
+               '404-pages-client.html'),
               text='default 404 page')
 
         publish_to_s3(**publish_kwargs)


### PR DESCRIPTION
## Changes proposed in this pull request:
- use pages 404 page

## security considerations
Will potentially break pages builds during the transition if the file is not found (in conjunction with https://github.com/cloud-gov/pages-404-page/pull/5)
