### PR TITLE
Restore File Diff for Publishing

### DIFF
--- a/src/publishing/models.py
+++ b/src/publishing/models.py
@@ -155,13 +155,14 @@ class SiteRedirect(SiteObject):
     A redirect, typically from `/path/to/page => /path/to/page/`
     '''
 
-    def __init__(self, filename, dir_prefix, site_prefix, base_url):
+    def __init__(self, filename, dir_prefix, site_prefix, base_url, cache_control):
         super().__init__(filename=filename,
                          dir_prefix=dir_prefix,
                          md5=None,  # update after super().__init()__
                          site_prefix=site_prefix)
 
         self.base_url = base_url
+        self.cache_control = cache_control
 
         # The md5 hash is the hash of the destination string, not
         # of the file contents, for our redirect objects
@@ -204,4 +205,5 @@ class SiteRedirect(SiteObject):
             Key=self.s3_key,
             ServerSideEncryption='AES256',
             WebsiteRedirectLocation=self.destination,
+            CacheControl=self.cache_control
         )

--- a/src/publishing/s3publisher.py
+++ b/src/publishing/s3publisher.py
@@ -4,7 +4,7 @@ Classes and methods for publishing a directory to S3
 
 import requests
 
-from os import path, makedirs, walk
+from os import path, makedirs, walk, getenv
 
 from log_utils import get_logger
 from .models import (remove_prefix, SiteObject, SiteFile, SiteRedirect)
@@ -17,7 +17,7 @@ def list_remote_objects(bucket, site_prefix, s3_client):
     '''
 
     Generates a list of remote S3 objects that have keys starting with
-    site_preix in the given bucket.
+    site_prefix in the given bucket.
 
     '''
     results_truncated = True
@@ -117,7 +117,8 @@ def publish_to_s3(directory, base_url, site_prefix, bucket, federalist_config,
                     site_redirect = SiteRedirect(filename=root,
                                                  dir_prefix=directory,
                                                  site_prefix=site_prefix,
-                                                 base_url=base_url)
+                                                 base_url=base_url,
+                                                 cache_control=cache_control)
 
                     local_objects_by_filename[site_redirect.filename] = site_redirect
 
@@ -140,11 +141,14 @@ def publish_to_s3(directory, base_url, site_prefix, bucket, federalist_config,
     # Create lists of all the new and modified objects
     new_objects = []
     replacement_objects = []
+    # track whether we can do diffing because of cache control
+    default_cache_control = getenv('CACHE_CONTROL', 'max-age=60')
     for local_filename, local_obj in local_objects_by_filename.items():
         matching_remote_obj = remote_objects_by_filename.get(local_filename)
         if not matching_remote_obj:
             new_objects.append(local_obj)
-        else:
+        elif (matching_remote_obj.md5 != local_obj.md5 or
+              local_obj.cache_control != default_cache_control):
             replacement_objects.append(local_obj)
 
     # Create a list of the remote objects that should be deleted

--- a/test/publishing/test_models.py
+++ b/test/publishing/test_models.py
@@ -45,6 +45,13 @@ class TestSiteObject():
             Bucket='test-bucket',
             Key='site/abc')
 
+    def test_upload_to_s3(self):
+        model = SiteObject('abc', 'md5')
+        # Base SiteObject should not have this method implemented
+        # because it is specific to file and redirect objects
+        with pytest.raises(NotImplementedError):
+            model.upload_to_s3('bucket', None)
+
 
 class TestSiteFile():
     @pytest.mark.parametrize('filename, is_compressible', [

--- a/test/publishing/test_models.py
+++ b/test/publishing/test_models.py
@@ -13,7 +13,7 @@ class TestSiteObject():
             filename='boop',
             md5='md5',
             dir_prefix='dir_prefix',
-            site_prefix='site_prefix',
+            site_prefix='site_prefix'
         )
         assert model is not None
 
@@ -34,13 +34,6 @@ class TestSiteObject():
         model = SiteObject('/not_dir/abc', 'md5',
                            dir_prefix='/dir', site_prefix='site')
         assert model.s3_key == 'site//not_dir/abc'
-
-    def test_upload_to_s3(self):
-        model = SiteObject('abc', 'md5')
-        # Base SiteObject should not have this method implemented
-        # because it is specific to file and redirect objects
-        with pytest.raises(NotImplementedError):
-            model.upload_to_s3('bucket', None)
 
     def test_delete_from_s3(self):
         s3_client = Mock()
@@ -147,7 +140,7 @@ class TestSiteFile():
 
 
 class TestSiteRedirect():
-    def test_contructor_and_props(self, tmpdir):
+    def test_constructor_and_props(self, tmpdir):
         base_test_dir = tmpdir.mkdir('boop')
         test_dir = base_test_dir.mkdir('sub_dir')
 
@@ -155,7 +148,8 @@ class TestSiteRedirect():
             filename=str(test_dir),
             dir_prefix=str(base_test_dir),
             site_prefix='prefix',
-            base_url='/preview'
+            base_url='/preview',
+            cache_control='max-age=60'
         )
 
         assert model is not None
@@ -185,7 +179,8 @@ class TestSiteRedirect():
             filename=str(test_dir),
             dir_prefix=str(base_test_dir),
             site_prefix='site-prefix',
-            base_url='/site/test'
+            base_url='/site/test',
+            cache_control='max-age=60'
         )
 
         s3_client = Mock()
@@ -198,5 +193,6 @@ class TestSiteRedirect():
             Bucket='test-bucket',
             Key='site-prefix/wherever',
             ServerSideEncryption='AES256',
-            WebsiteRedirectLocation=expected_dest
+            WebsiteRedirectLocation=expected_dest,
+            CacheControl="max-age=60",
         )

--- a/test/publishing/test_s3publisher.py
+++ b/test/publishing/test_s3publisher.py
@@ -23,7 +23,10 @@ def s3_client(monkeypatch):
     with mock_s3():
         conn = boto3.resource('s3', region_name=TEST_REGION)
 
-        conn.create_bucket(Bucket=TEST_BUCKET)
+        conn.create_bucket(
+            Bucket=TEST_BUCKET,
+            CreateBucketConfiguration={"LocationConstraint": "test-bucket"}
+        )
 
         s3_client = boto3.client(
             service_name='s3',
@@ -131,14 +134,12 @@ def test_publish_to_s3(tmpdir, s3_client):
 
         keys = [r['Key'] for r in results['Contents']]
 
-        assert results['KeyCount'] == 6  # 4 files, 3 redirects & 404.html
+        assert results['KeyCount'] == 6
 
         assert f'{site_prefix}/index.html' in keys
         assert f'{site_prefix}/boop.txt' in keys
-        assert f'{site_prefix}/sub_dir' in keys
         assert f'{site_prefix}/sub_dir/index.html' in keys
         assert f'{site_prefix}/404.html' in keys
-        assert f'{site_prefix}' in keys  # main redirect object
 
         # Check the cache control headers
         cache_control_checks = [

--- a/test/publishing/test_s3publisher.py
+++ b/test/publishing/test_s3publisher.py
@@ -134,12 +134,14 @@ def test_publish_to_s3(tmpdir, s3_client):
 
         keys = [r['Key'] for r in results['Contents']]
 
-        assert results['KeyCount'] == 6
+        assert results['KeyCount'] == 6 # 4 files, 3 redirects & 404.html
 
         assert f'{site_prefix}/index.html' in keys
         assert f'{site_prefix}/boop.txt' in keys
+        assert f'{site_prefix}/sub_dir' in keys
         assert f'{site_prefix}/sub_dir/index.html' in keys
         assert f'{site_prefix}/404.html' in keys
+        assert f'{site_prefix}' in keys # main redirect object
 
         # Check the cache control headers
         cache_control_checks = [

--- a/test/publishing/test_s3publisher.py
+++ b/test/publishing/test_s3publisher.py
@@ -134,14 +134,14 @@ def test_publish_to_s3(tmpdir, s3_client):
 
         keys = [r['Key'] for r in results['Contents']]
 
-        assert results['KeyCount'] == 6 # 4 files, 3 redirects & 404.html
+        assert results['KeyCount'] == 6  # 4 files, 3 redirects & 404.html
 
         assert f'{site_prefix}/index.html' in keys
         assert f'{site_prefix}/boop.txt' in keys
         assert f'{site_prefix}/sub_dir' in keys
         assert f'{site_prefix}/sub_dir/index.html' in keys
         assert f'{site_prefix}/404.html' in keys
-        assert f'{site_prefix}' in keys # main redirect object
+        assert f'{site_prefix}' in keys  # main redirect object
 
         # Check the cache control headers
         cache_control_checks = [

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -1,9 +1,4 @@
-import boto3
-import pytest
-
 from unittest.mock import Mock
-
-from moto import mock_s3
 
 from steps import publish
 from common import SITE_BUILD_DIR_PATH
@@ -15,21 +10,8 @@ TEST_ACCESS_KEY = 'fake-access-key'
 TEST_SECRET_KEY = 'fake-secret-key'
 
 
-@pytest.fixture
-def s3_conn(monkeypatch):
-    with mock_s3():
-        conn = boto3.resource(
-            's3',
-            aws_access_key_id=TEST_ACCESS_KEY,
-            aws_secret_access_key=TEST_SECRET_KEY,
-            region_name=TEST_BUCKET
-        )
-        conn.create_bucket(Bucket=TEST_BUCKET)
-        yield conn
-
-
 class TestPublish():
-    def test_it_calls_publish_to_s3(self, monkeypatch, s3_conn):
+    def test_it_calls_publish_to_s3(self, monkeypatch):
         mock_publish_to_s3 = Mock()
         monkeypatch.setattr('publishing.s3publisher.publish_to_s3',
                             mock_publish_to_s3)


### PR DESCRIPTION
## Changes proposed in this pull request:
- add back diffing for file publishing if cache-control matches default https://github.com/cloud-gov/pages-core/issues/2549
- drop site-redirects #229 as https://github.com/cloud-gov/pages-proxy/issues/113 seems complete

## Notes
This undoes [this portion](https://github.com/cloud-gov/pages-build-container/pull/198/files#diff-cd275d3426237b1720144a20871e990f094ae182b6d95eca5380f8b5d517a7b1L153-L155) of the Cache-Control PR, namely: it still checks to see if the file is actually updated UNLESS the file has non-default cache-control headers in which case we need to republish no matter what (since we don't know what they were formerly without another get_object request)

## security considerations
None
