### PR TITLE
chore: update accepted node versions

### DIFF
--- a/src/steps/build.py
+++ b/src/steps/build.py
@@ -148,19 +148,19 @@ def setup_node():
             runp("""
                 RAW_VERSION=$(nvm version-remote $(cat .nvmrc))
                 MAJOR_VERSION=$(echo $RAW_VERSION | cut -d. -f 1 | cut -dv -f 2)
-                if [[ "$MAJOR_VERSION" =~ ^(12|14|16)$ ]]; then
+                if [[ "$MAJOR_VERSION" =~ ^(14|16|18)$ ]]; then
                     echo "Switching to node version $RAW_VERSION specified in .nvmrc"
 
-                    if [[ "$MAJOR_VERSION" -eq 12 ]]; then
-                        echo "WARNING: Node $RAW_VERSION will reach end-of-life on 4-30-2022, at which point Pages will no longer support it."
-                        echo "Please upgrade to LTS major version 14 or 16, see https://nodejs.org/en/about/releases/ for details."
+                    if [[ "$MAJOR_VERSION" -eq 14 ]]; then
+                        echo "WARNING: Node $RAW_VERSION will reach end-of-life on 4-30-2023, at which point Pages will no longer support it."
+                        echo "Please upgrade to LTS major version 16 or 18, see https://nodejs.org/en/about/releases/ for details."
                     fi
 
                     nvm install $RAW_VERSION
                     nvm alias default $RAW_VERSION
                 else
                     echo "Unsupported node major version '$MAJOR_VERSION' specified in .nvmrc."
-                    echo "Please upgrade to LTS major version 14 or 16, see https://nodejs.org/en/about/releases/ for details."
+                    echo "Please upgrade to LTS major version 16 or 18, see https://nodejs.org/en/about/releases/ for details."
                     exit 1
                 fi
             """)  # noqa: E501


### PR DESCRIPTION
## Changes proposed in this pull request:
- accept node v18 as LTS
- warn on use of node v14
- remove use of node v12
- close #381

## security considerations
None
