### PR TITLE
chore: Add gem update --system for Jekyll builds

### DIFF
--- a/src/steps/build.py
+++ b/src/steps/build.py
@@ -301,6 +301,8 @@ def setup_ruby():
     if returncode:
         return returncode
 
+    runp(f'gem update --system')
+
     return runp('echo Ruby version: $(ruby -v)')
 
 

--- a/src/steps/build.py
+++ b/src/steps/build.py
@@ -301,7 +301,7 @@ def setup_ruby():
     if returncode:
         return returncode
 
-    runp(f'gem update --system')
+    runp('gem update --system')
 
     return runp('echo Ruby version: $(ruby -v)')
 

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -236,7 +236,7 @@ class TestSetupRuby():
 
         mock_logger = mock_get_logger.return_value
 
-        mock_run.assert_called_once_with(
+        mock_run.assert_called_with(
             mock_logger,
             'echo Ruby version: $(ruby -v)',
             cwd=patch_clone_dir,
@@ -270,6 +270,7 @@ class TestSetupRuby():
 
         mock_run.assert_has_calls([
             callp(f'rvm install {version}'),
+            callp('gem update --system'),
             callp('echo Ruby version: $(ruby -v)')
         ])
 
@@ -303,6 +304,7 @@ class TestSetupRuby():
 
         mock_run.assert_has_calls([
             callp("rvm install '$2.3'"),
+            callp('gem update --system'),
             callp('echo Ruby version: $(ruby -v)'),
         ])
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Run `gem update --system` to update RubyGems managing ruby packages
- Fixes installs for some gems where the older version `gem install` may cause problems

## security considerations
Updates system to use newer version of RubyGems package mgmt