### PR TITLE
Cache dependencies hotfix 2

### DIFF
--- a/src/steps/build.py
+++ b/src/steps/build.py
@@ -185,8 +185,7 @@ def setup_node(should_cache: bool, bucket, s3_client):
                 cache_folder = CacheFolder(PACKAGE_LOCK_PATH, NM_FOLDER, bucket, s3_client, logger)
                 cache_folder.download_unzip()
 
-        PACKAGE_JSON_PATH = CLONE_DIR_PATH / PACKAGE_JSON
-        if PACKAGE_JSON_PATH.is_file():
+        if PACKAGE_LOCK_PATH.is_file():
             if should_cache and cache_folder.exists():
                 logger.info('skipping npm ci and using cache')
             else:

--- a/src/steps/build.py
+++ b/src/steps/build.py
@@ -189,7 +189,7 @@ def setup_node(should_cache: bool, bucket, s3_client):
             if should_cache and cache_folder.exists():
                 logger.info('skipping npm ci and using cache')
             else:
-                logger.info('Installing dependencies in package.json')
+                logger.info('Installing dependencies in package-lock.json')
                 runp('npm set audit false')
                 runp('npm ci')
 

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -62,7 +62,7 @@ class TestSetupNode():
         )
 
     def test_installs_deps(self, mock_get_logger, mock_run, patch_clone_dir):
-        create_file(patch_clone_dir / PACKAGE_JSON)
+        create_file(patch_clone_dir / PACKAGE_LOCK)
 
         result = setup_node(False, None, None)
 
@@ -74,7 +74,7 @@ class TestSetupNode():
 
         mock_logger.info.assert_has_calls([
             call('Using default node version'),
-            call('Installing dependencies in package.json')
+            call('Installing dependencies in package-lock.json')
         ])
 
         def callp(cmd):


### PR DESCRIPTION
## Changes proposed in this pull request:
- explicitly build using package-lock.json (on which `npm ci` is dependent)

## security considerations
None
