### PR TITLE
ci: Update nightly deploy to just restage app

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -119,29 +119,6 @@ jobs:
             username: ((slack-username))
             icon_url: ((slack-icon-url))
 
-  - name: test-nightly-((deploy-env))
-    plan:
-      - get: nightly
-        trigger: true
-    on_success:
-      put: slack
-      params:
-        text: |
-          :x: SUCCESS: pages build container nightly redeploy on ((deploy-env))
-          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-        channel: ((slack-channel))
-        username: ((slack-username))
-        icon_url: ((slack-icon-url))
-    on_failure:
-      put: slack
-      params:
-        text: |
-          :x: FAILED: pages build container nightly redeploy on ((deploy-env))
-          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-        channel: ((slack-channel))
-        username: ((slack-username))
-        icon_url: ((slack-icon-url))
-
   - name: deploy-((deploy-env))
     plan:
       - get: src
@@ -186,38 +163,31 @@ jobs:
 
   - name: nightly-((deploy-env))
     plan:
-      - get: src
-        resource: src-((deploy-env))
-        params: {depth: 1}
-        passed: [test-nightly-((deploy-env))]
       - get: nightly
         trigger: true
-      - put: build-container-image
-        params:
-          build: src
-      - task: deploy
+      - task: restage
         config:
           <<: *cf-image
-          inputs:
-            - name: src
-            - name: build-container-image
           run:
             dir: src
-            path: ci/tasks/deploy.sh
+            path: ci/tasks/restage.sh
         params:
           <<: *env-cf
           CF_APP_NAME: pages-build-container-((deploy-env))
-          CF_MANIFEST: .cloudgov/manifest.yml
-          CF_VARS_FILE: .cloudgov/vars/pages-((deploy-env)).yml
-          CF_DOCKER_IMAGE_DIGEST: ../build-container-image/digest
-          CF_DOCKER_IMAGE_REPOSITORY: ((image-repository))
-          CF_DOCKER_USERNAME: ((docker-username))
-          CF_DOCKER_PASSWORD: ((docker-password))
+    on_success:
+      put: slack
+      params:
+        text: |
+          :x: SUCCESS: pages build container nightly restage on ((deploy-env))
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: ((slack-channel))
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
     on_failure:
       put: slack
       params:
         text: |
-          :x: FAILED: pages build container deployment on ((deploy-env))
+          :x: FAILED: pages build container nightly restage on ((deploy-env))
           <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
         channel: ((slack-channel))
         username: ((slack-username))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -56,20 +56,20 @@ jobs:
 
   - name: test-pr-((git-branch))
     plan:
-    - get: src
-      resource: pr-((git-branch))
-      trigger: true
-      version: every
+      - get: src
+        resource: pr-((git-branch))
+        trigger: true
+        version: every
 
-    - put: src
-      resource: pr-((git-branch))
-      params:
-        path: src
-        status: pending
-        base_context: concourse
-        context: test-pages-build-container-((deploy-env))
+      - put: src
+        resource: pr-((git-branch))
+        params:
+          path: src
+          status: pending
+          base_context: concourse
+          context: test-pages-build-container-((deploy-env))
 
-    - do: *test
+      - do: *test
 
     on_failure:
       put: src
@@ -121,17 +121,22 @@ jobs:
 
   - name: test-nightly-((deploy-env))
     plan:
-      - get: src
-        resource: src-((deploy-env))
-        params: {depth: 1}
       - get: nightly
         trigger: true
-      - do: *test
+    on_success:
+      put: slack
+      params:
+        text: |
+          :x: SUCCESS: pages build container nightly redeploy on ((deploy-env))
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: ((slack-channel))
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
     on_failure:
       put: slack
       params:
         text: |
-          :x: FAILED: pages build container tests on ((deploy-env))
+          :x: FAILED: pages build container nightly redeploy on ((deploy-env))
           <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
         channel: ((slack-channel))
         username: ((slack-username))


### PR DESCRIPTION
## Changes proposed in this pull request:
- Switch to only restage build container app
- Remove tests/container build running from the nightly trigger

## security considerations
Only restages the build-container app
