### PR TITLE
fix: CI pipeline to properly use src input for nightly rebuild

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -165,9 +165,14 @@ jobs:
     plan:
       - get: nightly
         trigger: true
+      - get: src
+        resource: src-((deploy-env))
+        trigger: true
+        params: {depth: 1}
       - task: restage
         config:
           <<: *cf-image
+          inputs: [name: src]
           run:
             dir: src
             path: ci/tasks/restage.sh


### PR DESCRIPTION
## Changes proposed in this pull request:
- FIx the CI pipeline for nightly build to pull in the source code repository to run the restage script

## security considerations
None
