### PR TITLE
Resolve Jekyll Installation Errors

### DIFF
--- a/src/steps/build.py
+++ b/src/steps/build.py
@@ -335,7 +335,7 @@ def setup_bundler(should_cache: bool, bucket, s3_client):
 
     if not GEMFILE_PATH.is_file():
         logger.info('No Gemfile found, installing Jekyll.')
-        return runp('gem install jekyll --no-document')
+        return runp('gem install jekyll -v 4.2.2 --no-document')
 
     logger.info('Gemfile found, setting up bundler')
 

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -392,7 +392,8 @@ class TestSetupBundler():
         ])
 
         mock_run.assert_called_once_with(
-            mock_logger, 'gem install jekyll -v 4.2.2 --no-document', cwd=patch_clone_dir, env={}, ruby=True
+            mock_logger, 'gem install jekyll -v 4.2.2 --no-document',
+            cwd=patch_clone_dir, env={}, ruby=True
         )
 
     def test_it_uses_default_version_if_only_gemfile_exits(self, mock_get_logger,

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -392,7 +392,7 @@ class TestSetupBundler():
         ])
 
         mock_run.assert_called_once_with(
-            mock_logger, 'gem install jekyll --no-document', cwd=patch_clone_dir, env={}, ruby=True
+            mock_logger, 'gem install jekyll -v 4.2.2 --no-document', cwd=patch_clone_dir, env={}, ruby=True
         )
 
     def test_it_uses_default_version_if_only_gemfile_exits(self, mock_get_logger,


### PR DESCRIPTION
## Changes proposed in this pull request:
- absent Gemfile, pin jekyll to v4.2.2
- close #409 

## security considerations
Jekyll >4.3 [prevents the installation of an insecure version of `kramdown`](https://jekyllrb.com/news/2022/10/20/jekyll-4-3-0-released/#bug-fixes) but testing on our container shows that we also install a secure version `2.4.0`.
