### PR TITLE
feat: Switch to using harden container for cf-image

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -20,9 +20,14 @@ python-image: &python-image
 cf-image: &cf-image
   platform: linux
   image_resource:
-    type: docker-image
+    type: registry-image
     source:
       repository: 18fgsa/concourse-task
+      aws_access_key_id: ((ecr-aws-key))
+      aws_secret_access_key: ((ecr-aws-secret))
+      repository: harden-concourse-task
+      aws_region: us-gov-west-1
+      tag: ((harden-concourse-task-tag))
 
 test: &test
   - task: test


### PR DESCRIPTION
Related to https://github.com/cloud-gov/pages-core/issues/4077

## Changes proposed in this pull request:
- Update cf-image to use hardened container image

## security considerations
This adds the hardened container to run CF tasks
