### PR TITLE
use rubygems 3.4.13 on container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ RUN source /usr/local/rvm/scripts/rvm \
 
 # Update to the latest RubyGems
 RUN source /usr/local/rvm/scripts/rvm \
-    rvm rubygems latest
+    rvm rubygems 3.4.13
 
 # Default to Node 16
 ENV NODE_VERSION lts/gallium

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,10 @@ RUN source /usr/local/rvm/scripts/rvm \
   # Make rvm available in non-login bash shells
   && echo 'source /usr/local/rvm/scripts/rvm' >> ~/.bashrc
 
+# Update to the latest RubyGems
+RUN source /usr/local/rvm/scripts/rvm \
+    rvm rubygems latest
+
 # Default to Node 16
 ENV NODE_VERSION lts/gallium
 RUN curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash \


### PR DESCRIPTION
## Changes proposed in this pull request:
- use latest rubygems on container build
- close #426
- specifically this is pinned to `3.4.13`. [The documentation](https://rvm.io/rubies/rubygems) doesn't entirely explain what's happening but it seems like `rvm rubygems latest` will only install up to a certain version of Rubygems for the current version of Ruby. Because our base Ruby version is behind, we need to bump the Rubygems version up manually until have another container solution.

## security considerations
None, potentially a security benefit with an updated version of RubyGems, pinned to a specific version so we should review periodically
