### PR TITLE
chore: Simplify CI notifications from task hooks

### DIFF
--- a/ci/pipeline-dev.yml
+++ b/ci/pipeline-dev.yml
@@ -148,15 +148,14 @@ jobs:
           CF_DOCKER_PASSWORD: ((ecr-aws-secret))
 
     on_failure:
-      in_parallel:
-        - put: slack
-          params:
-            text: |
-              :x: FAILED: pages build container deployment on ((deploy-env))
-              <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-            channel: ((slack-channel))
-            username: ((slack-username))
-            icon_url: ((slack-icon-url))
+      put: slack
+      params:
+        text: |
+          :x: FAILED: pages build container deployment on ((deploy-env))
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: ((slack-channel))
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
 
   - name: nightly-((deploy-env))
     plan:
@@ -192,23 +191,6 @@ jobs:
         channel: ((slack-channel))
         username: ((slack-username))
         icon_url: ((slack-icon-url))
-
-  - name: report-success-((deploy-env))
-    plan:
-      - get: src
-        resource: pr-((git-branch))
-        trigger: true
-        passed: [deploy-((deploy-env))]
-    on_success:
-      in_parallel:
-        - put: slack
-          params:
-            text: |
-              :white_check_mark: SUCCESS: Successfully deployed pages build containers on ((deploy-env))
-              <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-            channel: ((slack-channel))
-            username: ((slack-username))
-            icon_url: ((slack-icon-url))
 
 ############################
 #  RESOURCES

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -264,6 +264,15 @@ resources:
 
 resource_types:
 
+  - name: git
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: git-resource
+      aws_region: us-gov-west-1
+      tag: latest
+
   - name: slack-notification
     type: registry-image
     source:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -100,35 +100,17 @@ jobs:
         resource: src-((deploy-env))
         trigger: true
         params: {depth: 1}
-      - put: pr-((git-branch))
-        params:
-          path: pull-request
-          status: pending
-          context: concourse
       - do: *test
 
-    on_success:
-      put: pr-((git-branch))
-      params:
-        path: pull-request
-        status: success
-        context: concourse
-
     on_failure:
-      in_parallel:
-        - put: pr-((git-branch))
-          params:
-            path: pull-request
-            status: failure
-            context: concourse
-        - put: slack
-          params:
-            text: |
-              :x: FAILED: pages build container tests on ((deploy-env))
-              <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-            channel: ((slack-channel))
-            username: ((slack-username))
-            icon_url: ((slack-icon-url))
+      put: slack
+      params:
+        text: |
+          :x: FAILED: pages build container tests on ((deploy-env))
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: ((slack-channel))
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
 
   - name: deploy-((deploy-env))
     plan:
@@ -176,21 +158,25 @@ jobs:
           CF_DOCKER_USERNAME: ((ecr-aws-key))
           CF_DOCKER_PASSWORD: ((ecr-aws-secret))
 
+    on_success:
+      put: slack
+      params:
+        text: |
+          :white_check_mark: SUCCESS: Successfully deployed pages build containers on ((deploy-env))
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: ((slack-channel))
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+
     on_failure:
-      in_parallel:
-        - put: pr-((git-branch))
-          params:
-            path: pull-request
-            status: failure
-            context: concourse
-        - put: slack
-          params:
-            text: |
-              :x: FAILED: pages build container deployment on ((deploy-env))
-              <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-            channel: ((slack-channel))
-            username: ((slack-username))
-            icon_url: ((slack-icon-url))
+      put: slack
+      params:
+        text: |
+          :x: FAILED: pages build container deployment on ((deploy-env))
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: ((slack-channel))
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
 
   - name: nightly-((deploy-env))
     plan:
@@ -228,29 +214,6 @@ jobs:
         channel: ((slack-channel))
         username: ((slack-username))
         icon_url: ((slack-icon-url))
-
-  - name: report-success-((deploy-env))
-    plan:
-      - get: src
-        resource: src-((deploy-env))
-        trigger: true
-        params: {depth: 1}
-        passed: [deploy-((deploy-env))]
-    on_success:
-      in_parallel:
-        - put: pr-((git-branch))
-          params:
-            path: pull-request
-            status: success
-            context: concourse
-        - put: slack
-          params:
-            text: |
-              :white_check_mark: SUCCESS: Successfully deployed pages build containers on ((deploy-env))
-              <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-            channel: ((slack-channel))
-            username: ((slack-username))
-            icon_url: ((slack-icon-url))
 
 ############################
 #  RESOURCES


### PR DESCRIPTION
## Changes proposed in this pull request:
- Move all slack notifications to `on_<x>` task hooks
- Remove duplicative report status task
- Remove github status updates from branch test
- Add hardened git resource type to ci

## security considerations
Hardening
