### PR TITLE
save build container metrics

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 requests==2.31.0
 boto3==1.14.20
-humanize==4.4.0
 stopit==1.1.2
 psycopg2==2.9.9
 cryptography==42.0.2

--- a/src/log_utils/remote_logs.py
+++ b/src/log_utils/remote_logs.py
@@ -2,6 +2,7 @@
 
 import base64
 import requests
+from typing import Dict
 
 from .common import (STATUS_COMPLETE, STATUS_ERROR, STATUS_PROCESSING)
 
@@ -63,3 +64,15 @@ def post_build_timeout(status_callback_url, commit_sha=None):
 
     # Post to the Pages web application with status and output
     post_status(status_callback_url, status=STATUS_ERROR, output=output, commit_sha=commit_sha)
+
+
+def post_metrics(status_callback_url: str, metrics: Dict):
+    '''
+    POST build metrics to the metrics API
+    '''
+    url = status_callback_url.replace('status', 'metrics')
+    requests.post(
+        url,
+        json=metrics,
+        timeout=10
+    )

--- a/src/steps/fetch.py
+++ b/src/steps/fetch.py
@@ -50,7 +50,7 @@ def fetch_repo(owner, repository, branch, github_token=''):  # nosec
         f'{CLONE_DIR_PATH}'
     )
 
-    return run(logger, command, env=clone_env)
+    return run(logger, command, env=clone_env, check=False)
 
 
 def update_repo(clone_dir):

--- a/test/test_fetch.py
+++ b/test/test_fetch.py
@@ -28,7 +28,7 @@ class TestCloneRepo():
 
         mock_get_logger.assert_called_once_with('clone')
 
-        mock_run.assert_called_once_with(mock_get_logger.return_value, command, env=clone_env)
+        mock_run.assert_called_once_with(mock_get_logger.return_value, command, env=clone_env, check=False)  # noqa: 501
 
     def test_runs_expected_cmds_with_gh_token(self, mock_get_logger, mock_run):
         owner = 'owner-2'
@@ -44,7 +44,7 @@ class TestCloneRepo():
 
         mock_get_logger.assert_called_once_with('clone')
 
-        mock_run.assert_called_once_with(mock_get_logger.return_value, command, env=clone_env)
+        mock_run.assert_called_once_with(mock_get_logger.return_value, command, env=clone_env, check=False)  # noqa: 501
 
 
 class TestCloneRepoNoMock(unittest.TestCase):
@@ -57,6 +57,7 @@ class TestCloneRepoNoMock(unittest.TestCase):
         repository = 'cg-site'
         branch = 'master'
 
+        # TODO: this is a totally useless test because the CI runner doesn't have git
         with self._caplog.at_level(logging.INFO):
             fetch_repo(owner, repository, branch)
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- With the availability of the [build metrics API](https://github.com/cloud-gov/pages-core/pull/4495), we can now send metrics back from the controller in this fashion: https://github.com/cloud-gov/pages-core/blob/main/docs/DEVELOPMENT.md#build-metrics-api
- Updates the general `runner` pattern to fail loudly rather than return a `returncode` and each step is run with this in mind.
- Stops logging the monitoring metrics (CPU/memory/disk) and sends that back to the API instead
- Related test updates

## Notes
- For an example of this working, check out build `560` on dev

## security considerations
Sends information back to a new API endpoint, updated use of `subprocess.run`