### PR TITLE
Add dependency auditing to pipelines

### DIFF
--- a/ci/pipeline-dev.yml
+++ b/ci/pipeline-dev.yml
@@ -192,6 +192,65 @@ jobs:
         username: ((slack-username))
         icon_url: ((slack-icon-url))
 
+  - name: audit-dependencies
+    plan:
+      - get: src
+        resource: pr-((git-branch))
+        trigger: true
+        passed: [set-pipeline]
+
+      - put: src
+        resource: pr-((git-branch))
+        params:
+          path: src
+          status: pending
+          base_context: concourse
+          context: audit-dependencies
+
+      - task: pip-audit
+        config:
+          <<: *python-image
+          inputs: [name: src]
+          outputs: [name: src]
+          run:
+            dir: src
+            path: ci/tasks/pip-audit.sh
+
+    on_failure:
+      in_parallel:
+        - put: src
+          resource: pr-((git-branch))
+          params:
+            path: src
+            status: failure
+            base_context: concourse
+            context: audit-dependencies
+        - put: slack
+          params:
+            text: |
+              :x: FAILED: pages build container dependency audit on ((git-branch))
+              <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME?vars.deploy-env="((deploy-env))"&vars.git-branch="((git-branch))"|View build details>
+            channel: ((slack-channel))
+            username: ((slack-username))
+            icon_url: ((slack-icon-url))
+
+    on_success:
+      in_parallel:
+        - put: src
+          resource: pr-((git-branch))
+          params:
+            path: src
+            status: success
+            base_context: concourse
+            context: audit-dependencies
+        - put: slack
+          params:
+            text: |
+              :white_check_mark: SUCCESS: Successfully passed pages build container dependency audit on ((git-branch))
+            channel: ((slack-channel))
+            username: ((slack-username))
+            icon_url: ((slack-icon-url))
+
 ############################
 #  RESOURCES
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -215,6 +215,65 @@ jobs:
         username: ((slack-username))
         icon_url: ((slack-icon-url))
 
+  - name: audit-dependencies
+    plan:
+      - get: src
+        resource: src-((deploy-env))
+        trigger: true
+        passed: [set-pipeline]
+
+      - put: src
+        resource: src-((deploy-env))
+        params:
+          path: src
+          status: pending
+          base_context: concourse
+          context: audit-dependencies
+
+      - task: pip-audit
+        config:
+          <<: *python-image
+          inputs: [name: src]
+          outputs: [name: src]
+          run:
+            dir: src
+            path: ci/tasks/pip-audit.sh
+
+    on_failure:
+      in_parallel:
+        - put: src
+          resource: src-((deploy-env))
+          params:
+            path: src
+            status: failure
+            base_context: concourse
+            context: audit-dependencies
+        - put: slack
+          params:
+            text: |
+              :x: FAILED: pages build container dependency audit on ((deploy-env))
+              <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME?vars.deploy-env="((deploy-env))"&vars.git-branch="((git-branch))"|View build details>
+            channel: ((slack-channel))
+            username: ((slack-username))
+            icon_url: ((slack-icon-url))
+
+    on_success:
+      in_parallel:
+        - put: src
+          resource: src-((deploy-env))
+          params:
+            path: src
+            status: success
+            base_context: concourse
+            context: audit-dependencies
+        - put: slack
+          params:
+            text: |
+              :white_check_mark: SUCCESS: Successfully passed pages build container dependency audit on ((deploy-env))
+            channel: ((slack-channel))
+            username: ((slack-username))
+            icon_url: ((slack-icon-url))
+
 ############################
 #  RESOURCES
 

--- a/ci/tasks/pip-audit.sh
+++ b/ci/tasks/pip-audit.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+pip install pip-audit
+
+python3 -m pip_audit -r ./requirements.txt
+
+exit $status

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@
 bandit>=1.0,<2.0
 flake8==3.8.3
 moto==5.0.1
+pip-audit==2.7.3
 pyfakefs==4.0.2
 pyflakes==2.2.0
 pylint==2.5.3


### PR DESCRIPTION
Part of #458 

## Changes proposed in this pull request:
- Add [pip-audit](https://github.com/pypa/pip-audit) as a dev dependency.
- Add `pip-audit.sh` script and new `audit-dependencies` tasks which run it in the CI pipelines.

## security considerations
None. This introduces a new check to help ensure that out-of-date dependencies get resolved. 
