### PR TITLE
fix: Run build CalledProcessError exception

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.31.0
+requests==2.32.3
 boto3==1.34.102
 stopit==1.1.2
 psycopg2==2.9.9

--- a/src/build.py
+++ b/src/build.py
@@ -25,10 +25,9 @@ import repo_config
 
 from steps import (
     build_hugo, build_jekyll, build_static, download_hugo,
-    fetch_repo, publish, run_build_script, fetch_commit_sha,
+    fetch_repo, publish, run_build_script, run_step, fetch_commit_sha,
     setup_bundler, setup_node, setup_ruby, StepException, update_repo
 )
-
 
 TIMEOUT_SECONDS = 45 * 60  # 45 minutes
 
@@ -96,13 +95,6 @@ def build(
 
             # partially apply the callback url to post_metrics
             post_metrics_p = partial(post_metrics, status_callback)
-
-            def run_step(step, msg, *args, **kwargs):
-                try:
-                    step(*args, **kwargs)
-                except Exception as e:
-                    logger.error(e)
-                    raise StepException(msg)
 
             logger.info(f'Running build for {owner}/{repository}/{branch}')
 

--- a/src/steps/__init__.py
+++ b/src/steps/__init__.py
@@ -1,11 +1,12 @@
 from .build import (
     build_hugo, build_jekyll, build_static,
-    download_hugo, run_build_script, setup_bundler,
+    download_hugo, run_build_script, run_step, setup_bundler,
     setup_node, setup_ruby,
 )
 from .exceptions import StepException
 from .fetch import fetch_repo, update_repo, fetch_commit_sha
 from .publish import publish
+
 
 __all__ = [
     'build_hugo',
@@ -15,6 +16,7 @@ __all__ = [
     'fetch_repo',
     'publish',
     'run_build_script',
+    'run_step',
     'setup_bundler',
     'setup_node',
     'setup_ruby',

--- a/src/steps/build.py
+++ b/src/steps/build.py
@@ -14,6 +14,7 @@ from common import (CLONE_DIR_PATH, SITE_BUILD_DIR, SITE_BUILD_DIR_PATH, WORKING
 from log_utils import get_logger
 from runner import run, setuser
 from .cache import CacheFolder
+from .exceptions import StepException
 
 HUGO_BIN = 'hugo'
 HUGO_VERSION = '.hugo-version'
@@ -220,6 +221,13 @@ def run_build_script(branch, owner, repository, site_prefix,
             env = build_env(branch, owner, repository, site_prefix, base_url, user_env_vars)
             run(logger, f'npm run {script_name}', cwd=CLONE_DIR_PATH, env=env, node=True)
             return
+
+
+def run_step(step, msg, *args, **kwargs):
+    try:
+        step(*args, **kwargs)
+    except Exception:
+        raise StepException(msg)
 
 
 def download_hugo(post_metrics):

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -1,3 +1,4 @@
+from pytest import raises
 import json
 import os
 from io import StringIO
@@ -12,7 +13,7 @@ import yaml
 import steps
 from steps import (
     build_hugo, build_jekyll, build_static, download_hugo,
-    run_build_script, setup_bundler, setup_node, setup_ruby
+    run_build_script, run_step, setup_bundler, setup_node, setup_ruby, StepException
 )
 from steps.build import (
     build_env, check_supported_ruby_version, BUNDLER_VERSION, GEMFILE,
@@ -212,6 +213,19 @@ class TestRunBuildScript():
 
         mock_get_logger.assert_not_called()
         mock_run.assert_not_called()
+
+
+class TestRunStep():
+    def test_it_should_raise_an_exception(self):
+        msg = 'testing-msg'
+        arg1 = 'arg1'
+        kwarg1 = 'kwarg1'
+        mock_step = Mock(side_effect=KeyError)
+
+        with raises(StepException):
+            run_step(mock_step, msg, arg1, kwarg1=kwarg1)
+
+        mock_step.assert_called_once_with(arg1, kwarg1=kwarg1)
 
 
 @patch('steps.build.run')

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -216,7 +216,7 @@ class TestRunBuildScript():
 
 
 class TestRunStep():
-    def test_it_should_raise_an_exception(self):
+    def test_it_should_raise_an_exception_from_step(self):
         msg = 'testing-msg'
         arg1 = 'arg1'
         kwarg1 = 'kwarg1'
@@ -224,6 +224,17 @@ class TestRunStep():
 
         with raises(StepException):
             run_step(mock_step, msg, arg1, kwarg1=kwarg1)
+
+        mock_step.assert_called_once_with(arg1, kwarg1=kwarg1)
+
+    def test_it_should_run_step_successfully(self):
+        msg = 'testing-msg'
+        arg1 = 'arg1'
+        kwarg1 = 'kwarg1'
+        mock_step = Mock()
+        mock_step.return_value()
+
+        run_step(mock_step, msg, arg1, kwarg1=kwarg1)
 
         mock_step.assert_called_once_with(arg1, kwarg1=kwarg1)
 


### PR DESCRIPTION
Closes #468 

## Changes proposed in this pull request:
- Removes logging during a `run_step` raised exception
- Moved `run_step` function into `steps.build`
- Adds tests for `run_step` to verify pass and fail outcomes

## security considerations
Bump requests to v2.32.2
