### PR TITLE
Release 0.1.1

### DIFF
--- a/.cz.json
+++ b/.cz.json
@@ -1,0 +1,47 @@
+{
+  "commitizen": {
+    "name": "cz_customize",
+    "version_scheme": "semver",
+    "version_provider": "scm",
+    "update_changelog_on_bump": true,
+    "major_version_zero": false,
+    "bump_message": "chore: release $new_version",
+    "gpg_sign": true,
+    "changelog_incremental": true,
+    "customize": {
+      "message_template": "{{change_type}}:{% if show_message %} {{message}}{% endif %}",
+      "example": "feat: this feature enable customize through config file",
+      "schema": "<type>: <body>",
+      "schema_pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\\([\\w\\-\\.]+\\))?(!)?: ([\\w \\-'])+([\\s\\S]*)",
+      "bump_pattern": "^(.+!|BREAKING CHANGE|chore|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\-\\.]+\\))?:",
+      "bump_map": {
+          ".+!": "MAJOR",
+          "BREAKING CHANGE": "MAJOR",
+          "feat": "MINOR",
+          "fix": "PATCH",
+          "chore": "PATCH",
+          "docs": "PATCH",
+          "perf": "PATCH",
+          "refactor": "PATCH",
+          "revert": "MINOR",
+          "style": "PATCH",
+          "test": "PATCH"
+      },
+      "change_type_order": ["Breaking Changes", "Added", "Fixed", "Performance", "Reverted", "Maintenance", "Documentation"],
+      "commit_parser": "^((?P<change_type>chore|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE)(?:\\((?P<scope>[^()\r\n]*)\\)|\\()?(?P<breaking>!)?|\\w+!):\\s(?P<message>.*)?",
+      "changelog_pattern": "^(.+!|BREAKING CHANGE|chore|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\-\\.]+\\))?:",
+      "change_type_map": {
+        "BREAKING CHANGE": "Breaking Changes",
+        "chore": "Maintenance",
+        "docs": "Documentation",
+        "feat": "Added",
+        "fix": "Fixed",
+        "perf": "Performance",
+        "refactor": "Maintenance",
+        "revert": "Reverted",
+        "style": "Maintenance",
+        "test": "Maintenance"
+      }
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+## 0.1.1 (2024-06-24)
+
+### Maintenance
+
+- add release workflow, wait for certain passes
+
+## 0.1.0 (2024-06-21)
+
+### Added
+
+- save build container metrics to API
+- Add dev deployment env for PRs to staging
+- Switch to using harden container for cf-image
+
+### Fixed
+
+- Decrypt predefined keys in build params
+- Run build CalledProcessError exception
+- remove puts to git-resource in ci pipeline
+- install required usg dependencies
+- node 16 temporarily allowed
+- Add additional lib deps for site builds
+- Remove stack param since it is docker image
+- Update tests to account for request timeout kwarg addition
+- Add timeout to requests based on bandit findings
+- CI slack emoji for successful nightly restage
+- CI pipeline to properly use src input for nightly rebuild
+- Update tests with additional mock calls
+- Remove f-string for gem update command
+
+### Performance
+
+- run uploader task in threads
+
+### Maintenance
+
+- update docs, drop nightly restage
+- use correct input pipeline names
+- use pipeline tasks, use pr/main/tag release
+- Bump requests to v2.32.3
+- Add decrypt to build site params
+- Enable Dependabot security scanning (#458)
+- container hardening
+- Add dependency auditing with pip-audit (#458)
+- **ci**: Switch to general-task and registry-image for CI jobs
+- Add hardened git resource
+- Simplify CI notifications from task hooks
+- Update resource types and python deps to use hardened images
+- Adjust for Github GPG token expiration
+- don't build node 16
+- default to node 18 (#437)
+- Update app stack to cflinuxfs4
+- Add gem update --system for Jekyll builds

--- a/ci/pipeline-production.yml
+++ b/ci/pipeline-production.yml
@@ -30,6 +30,7 @@ jobs:
         resource: src-((deploy-env))-tagged
         trigger: true
         params: { depth: 1 }
+        passed: [set-pipeline]
       - get: python
       - task: test
         image: python
@@ -43,7 +44,7 @@ jobs:
         resource: src-((deploy-env))-tagged
         trigger: true
         params: { depth: 1 }
-        passed: [test-((deploy-env))]
+        passed: [test-((deploy-env)), audit-dependencies]
       - get: general-task
       - get: oci-build-task
       - task: build
@@ -83,6 +84,15 @@ jobs:
 
     on_failure: #@ slack_hook("failure", "dependency audit")
     on_success: #@ slack_hook("success", "dependency audit")
+
+  - name: release
+    plan:
+      - get: src
+        resource: src-((deploy-env))-tagged
+        params: { depth: 1 }
+        trigger: true
+        passed: [deploy-((deploy-env))]
+      -  #@ template.replace(data.values.release_steps)
 
 #!  RESOURCES
 

--- a/ci/pipeline-staging.yml
+++ b/ci/pipeline-staging.yml
@@ -24,12 +24,24 @@ jobs:
         instance_vars:
           deploy-env: ((deploy-env))
 
+  - name: update-release-branch
+    plan:
+      - get: src
+        resource: src-((deploy-env))
+        trigger: true
+      - get: general-task
+      - get: pipeline-tasks
+      - task: update-release-branch
+        image: general-task
+        file: pipeline-tasks/tasks/update-release-branch.yml
+
   - name: test-((deploy-env))
     plan:
       - get: src
         resource: src-((deploy-env))
         trigger: true
         params: { depth: 1 }
+        passed: [set-pipeline]
       - get: python
       - task: test
         image: python
@@ -43,7 +55,7 @@ jobs:
         resource: src-((deploy-env))
         trigger: true
         params: { depth: 1 }
-        passed: [test-((deploy-env))]
+        passed: [test-((deploy-env)), audit-dependencies]
       - get: general-task
       - get: oci-build-task
       - task: build
@@ -91,9 +103,10 @@ resources:
     type: git
     icon: github
     source:
-      uri: ((git-base-url))/((build-container-repository-path))
+      uri: git@github.com:/((build-container-repository-path))
       branch: main
       commit_verification_keys: ((cloud-gov-pages-gpg-keys))
+      private_key: ((pages-gpg-operations-github-sshkey.private_key))
 
   - name: image-repository
     type: registry-image


### PR DESCRIPTION
## :robot: This is an automated release PR
chore: release 0.1.1
tag to create: 0.1.1
increment detected: PATCH

## 0.1.1 (2024-06-24)

### Maintenance

- add release workflow, wait for certain passes

## 0.1.0 (2024-06-21)

### Added

- save build container metrics to API
- Add dev deployment env for PRs to staging
- Switch to using harden container for cf-image

### Fixed

- Decrypt predefined keys in build params
- Run build CalledProcessError exception
- remove puts to git-resource in ci pipeline
- install required usg dependencies
- node 16 temporarily allowed
- Add additional lib deps for site builds
- Remove stack param since it is docker image
- Update tests to account for request timeout kwarg addition
- Add timeout to requests based on bandit findings
- CI slack emoji for successful nightly restage
- CI pipeline to properly use src input for nightly rebuild
- Update tests with additional mock calls
- Remove f-string for gem update command

### Performance

- run uploader task in threads

### Maintenance

- update docs, drop nightly restage
- use correct input pipeline names
- use pipeline tasks, use pr/main/tag release
- Bump requests to v2.32.3
- Add decrypt to build site params
- Enable Dependabot security scanning (#458)
- container hardening
- Add dependency auditing with pip-audit (#458)
- **ci**: Switch to general-task and registry-image for CI jobs
- Add hardened git resource
- Simplify CI notifications from task hooks
- Update resource types and python deps to use hardened images
- Adjust for Github GPG token expiration
- don't build node 16
- default to node 18 (#437)
- Update app stack to cflinuxfs4
- Add gem update --system for Jekyll builds
## security considerations
Noted in individual PRs
