### PR TITLE
chore: Dependabot pip 18e15a66a3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ requests==2.32.3
 boto3==1.34.102
 stopit==1.1.2
 psycopg2==2.9.9
-cryptography==42.0.7
+cryptography==43.0.1
 pyyaml==6.0.1
 psutil==5.9.4


### PR DESCRIPTION
## Changes proposed in this pull request:
- Dependabot: Bump cryptography from 42.0.7 to 43.0.1 in the pip

## security considerations
Updates dependency