### PR TITLE
Release 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.1.2 (2024-10-29)
+
+### Maintenance
+
+- support node v22, warn on v18 (#4644)
+- Bump cryptography from 42.0.7 to 43.0.1 in the pip
+
 ## 0.1.1 (2024-06-28)
 
 ### Maintenance


### PR DESCRIPTION
## :robot: This is an automated release PR
chore: release 0.1.2
tag to create: 0.1.2
increment detected: PATCH

## 0.1.2 (2024-10-29)

### Maintenance

- support node v22, warn on v18 (#4644)
- Bump cryptography from 42.0.7 to 43.0.1 in the pip
## security considerations
Noted in individual PRs
