### PR TITLE
chore: Install and set default node to v20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,8 +102,8 @@ RUN source /usr/local/rvm/scripts/rvm \
 RUN source /usr/local/rvm/scripts/rvm && \
     rvm rubygems 3.4.22
 
-# Default to Node 18
-ENV NODE_VERSION lts/hydrogen
+# Default to Node 20
+ENV NODE_VERSION lts/iron
 RUN curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash \
   && \. "$HOME/.nvm/nvm.sh" \
   && nvm install $NODE_VERSION

--- a/Dockerfile-exp
+++ b/Dockerfile-exp
@@ -44,7 +44,7 @@ RUN mkdir -p /root/.gnupg \
   && echo 'disable-ipv6' >> /root/.gnupg/dirmngr.conf \
   && echo 'rvm_silence_path_mismatch_check_flag=1' >> /etc/rvmrc \
   && echo 'install: --no-document\nupdate: --no-document' >> /etc/.gemrc
-  
+
 RUN useradd --no-log-init --system --create-home --groups sudo system \
   && echo 'system ALL=(ALL:ALL) NOPASSWD:ALL' >> /etc/sudoers.d/system
 
@@ -91,8 +91,8 @@ RUN source /usr/local/rvm/scripts/rvm \
   # Make rvm available in non-login bash shells
   && echo 'source /usr/local/rvm/scripts/rvm' >> ~/.bashrc
 
-# Default to Node 18
-ENV NODE_VERSION lts/hydrogen
+# Default to Node 20
+ENV NODE_VERSION lts/iron
 RUN curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash \
   && \. "$HOME/.nvm/nvm.sh" \
   && nvm install $NODE_VERSION


### PR DESCRIPTION
Apart of https://github.com/cloud-gov/pages-build-container/issues/490

## Changes proposed in this pull request:
- Set installed, default node version to v20.

## security considerations
Update default node to v20
