### PR TITLE
chore: Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @cloud-gov/pages-ops


### PR DESCRIPTION
Closes https://github.com/cloud-gov/product/issues/3410

## Changes proposed in this pull request:
-Pages Ops owns it

## security considerations
No longer without a home, no longer like a complete unknown, no longer like a rolling stone.
