### PR TITLE
feat: Add Node.js v24 as the default node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,9 +102,9 @@ RUN source /usr/local/rvm/scripts/rvm \
 RUN source /usr/local/rvm/scripts/rvm && \
     rvm rubygems 3.4.22
 
-# Default to Node 20
-ENV NODE_VERSION lts/iron
-RUN curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash \
+# Default to Node 24
+ENV NODE_VERSION lts/krypton
+RUN curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash \
   && \. "$HOME/.nvm/nvm.sh" \
   && nvm install $NODE_VERSION
 

--- a/Dockerfile-exp
+++ b/Dockerfile-exp
@@ -91,9 +91,9 @@ RUN source /usr/local/rvm/scripts/rvm \
   # Make rvm available in non-login bash shells
   && echo 'source /usr/local/rvm/scripts/rvm' >> ~/.bashrc
 
-# Default to Node 20
-ENV NODE_VERSION lts/iron
-RUN curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash \
+# Default to Node 24
+ENV NODE_VERSION lts/krypton
+RUN curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash \
   && \. "$HOME/.nvm/nvm.sh" \
   && nvm install $NODE_VERSION
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 requests==2.32.4
 boto3==1.34.102
 stopit==1.1.2
-psycopg2==2.9.9
+psycopg2-binary==2.9.11
 cryptography==44.0.1
 pyyaml==6.0.1
 psutil==5.9.4

--- a/src/steps/build.py
+++ b/src/steps/build.py
@@ -152,19 +152,19 @@ def setup_node(should_cache: bool, bucket, s3_client, post_metrics):
         runp("""
             RAW_VERSION=$(nvm version-remote $(cat .nvmrc))
             MAJOR_VERSION=$(echo $RAW_VERSION | cut -d. -f 1 | cut -dv -f 2)
-            if [[ "$MAJOR_VERSION" =~ ^(18|20|22)$ ]]; then
+            if [[ "$MAJOR_VERSION" =~ ^(20|22|24)$ ]]; then
                 echo "Switching to node version $RAW_VERSION specified in .nvmrc"
 
-                if [[ "$MAJOR_VERSION" -eq 18 ]]; then
-                    echo "WARNING: Node $RAW_VERSION will reach end-of-life on 2025-04-30, at which point Pages will no longer support it."
-                    echo "Please upgrade to LTS major version 20 or 22, see https://nodejs.org/en/about/releases/ for details."
+                if [[ "$MAJOR_VERSION" -eq 20 ]]; then
+                    echo "WARNING: Node $RAW_VERSION will reach end-of-life in May 2026, at which point Pages will no longer support it."
+                    echo "Please upgrade to LTS major version 22 or 24, see https://nodejs.org/en/about/releases/ for details."
                 fi
 
                 nvm install $RAW_VERSION
                 nvm alias default $RAW_VERSION
             else
                 echo "Unsupported node major version '$MAJOR_VERSION' specified in .nvmrc."
-                echo "Please upgrade to LTS major version 20 or 22, see https://nodejs.org/en/about/releases/ for details."
+                echo "Please upgrade to LTS major version 22 or 24, see https://nodejs.org/en/about/releases/ for details."
                 exit 1
             fi
         """)  # noqa: E501


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds Node v24 and installs it as the default Node version
- Removes Node v18 support since it is past end of life
- Adds warning for Node v20 about upcoming end of life

## security considerations
Updates default to latest major Node LTS version
